### PR TITLE
support 5 digit parks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,6 @@ archives:
   format_overrides:
   - goos: windows
     format: zip
-  rlcp: true
   files:
       - README.md
       - doc/whats_new.md
@@ -111,7 +110,7 @@ brews:
     # same kind. We will probably unify this in the next major version like it is done with scoop.
 
     # GitHub/GitLab repository to push the formula to
-    tap:
+    repository:
       owner: on4kjm
       name: homebrew-tap
       # Optionally a branch can be provided. If the branch does not exist, it

--- a/fleprocess/validate.go
+++ b/fleprocess/validate.go
@@ -51,7 +51,7 @@ func ValidateWwff(inputStr string) (ref, errorMsg string) {
 	return wrongInputStr, errorMsg
 }
 
-var validPotaRegexp = regexp.MustCompile(`^[\d]{0,1}[A-Z]{1,2}-[\d]{4}$`)
+var validPotaRegexp = regexp.MustCompile(`^[\d]{0,1}[A-Z]{1,2}-[\d]{4,5}$`)
 
 // ValidatePota verifies whether the supplied string is a valid POTA reference.
 // The syntax is: AA-CCCC: AA = national prefix, CCCC = 4-digit numeric code (e.g. ON-0001).

--- a/fleprocess/validate.go
+++ b/fleprocess/validate.go
@@ -54,7 +54,7 @@ func ValidateWwff(inputStr string) (ref, errorMsg string) {
 var validPotaRegexp = regexp.MustCompile(`^[\d]{0,1}[A-Z]{1,2}-[\d]{4,5}$`)
 
 // ValidatePota verifies whether the supplied string is a valid POTA reference.
-// The syntax is: AA-CCCC: AA = national prefix, CCCC = 4-digit numeric code (e.g. ON-0001).
+// The syntax is: AA-CCCCC: AA = national prefix, CCCCC = 4 or 5-digit numeric code (e.g. ON-00001).
 func ValidatePota(inputStr string) (ref, errorMsg string) {
 	inputStr = strings.ToUpper(strings.TrimSpace(inputStr))
 	wrongInputStr := "*" + inputStr

--- a/fleprocess/validate_test.go
+++ b/fleprocess/validate_test.go
@@ -89,6 +89,11 @@ func TestValidatePota(t *testing.T) {
 			"4X-0258", "",
 		},
 		{
+			"Good ref (5 digit park)",
+			args{inputStr: "k-10177"},
+			"K-10177", "",
+		},
+		{
 			"Bad ref (no country prefix)",
 			args{inputStr: "-0258"},
 			"*-0258", "[-0258] is an invalid POTA reference",
@@ -104,9 +109,9 @@ func TestValidatePota(t *testing.T) {
 			"*ON-258", "[ON-258] is an invalid POTA reference",
 		},
 		{
-			"Bad ref (no country prefix)",
-			args{inputStr: "on-02589"},
-			"*ON-02589", "[ON-02589] is an invalid POTA reference",
+			"Bad ref (park number too long)",
+			args{inputStr: "on-123456"},
+			"*ON-123456", "[ON-123456] is an invalid POTA reference",
 		},
 	}
 	for _, tt := range tests {

--- a/test/commands.md
+++ b/test/commands.md
@@ -2,10 +2,9 @@
 
 * `./FLEcli -i test/data/fle-1.txt load`
 * `./FLEcli -i test/data/sample_contest_ru.txt load`
-* `go test ./...` runs the unit tests
+* `go test ./...` runs the unit tests, from project root
 
 * `./FLEcli -i test/data/ON4KJM@ONFF-025920200524.txt --interpolate adif --wwff --overwrite`
 * `./FLEcli adif -i=test/data/ON4KJM@ONFF-025920200524.txt --interpolate --wwff --overwrite`
-
 
 Install Bats: `brew install bats-core`


### PR DESCRIPTION
updated regex and tests to support new 5 digit parks
goreleaser changes made because of deprecations/changes in goreleaser