### PR TITLE
Permit comment after other input on the line

### DIFF
--- a/fleprocess/load_file.go
+++ b/fleprocess/load_file.go
@@ -53,6 +53,7 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 	isInferTimeFatalError := false
 
 	regexpLineComment := regexp.MustCompile(`^[[:blank:]]*#`)
+	regexpInLineComment := regexp.MustCompile(`.*#.*`)
 	regexpOnlySpaces := regexp.MustCompile(`^\s+$`)
 	regexpSingleMultiLineComment := regexp.MustCompile(`^[[:blank:]]*{.+}$`)
 	regexpStartMultiLineComment := regexp.MustCompile(`^[[:blank:]]*{`)
@@ -103,6 +104,10 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 		//Skip if line is empty or blank
 		if (len(eachline) == 0) || (regexpOnlySpaces.MatchString(eachline)) {
 			continue
+		}
+		// a comment starts somewhere on the line, remove the comment
+		if regexpInLineComment.MatchString(eachline) {
+			eachline = strings.Split(eachline, "#")[0]
 		}
 
 		// Process multi-line comments

--- a/fleprocess/load_file_test.go
+++ b/fleprocess/load_file_test.go
@@ -49,6 +49,7 @@ func TestLoadFile_happyCase(t *testing.T) {
 	dataArray = append(dataArray, "40m cw 0950 ik5zve/5 9 5")
 	dataArray = append(dataArray, "on6zq")
 	dataArray = append(dataArray, "0954 on4do")
+	dataArray = append(dataArray, "0955 k0emt # on line comment")
 
 	temporaryDataFileName := createTestFile(dataArray)
 
@@ -114,6 +115,14 @@ func TestLoadFile_happyCase(t *testing.T) {
 	expectedValue = "0954"
 	if loadedLogFile[2].Time != expectedValue {
 		t.Errorf("Not the expected Time[2] value: %s (expecting %s)", loadedLogFile[2].Time, expectedValue)
+	}
+	expectedValue = "K0EMT"
+	if loadedLogFile[3].Call != expectedValue {
+		t.Errorf("Not the expected Call[3] value: %s (expecting %s)", loadedLogFile[3].Call, expectedValue)
+	}
+	expectedValue = "0955"
+	if loadedLogFile[3].Time != expectedValue {
+		t.Errorf("Not the expected Time[3] value: %s (expecting %s)", loadedLogFile[3].Time, expectedValue)
 	}
 	//Clean Up
 	os.Remove(temporaryDataFileName)


### PR DESCRIPTION
The windows program permits things like:
K0EMT 599 599 # what was his state?
This bit of code strips the comment portion of the line and continues with processing.