### PR TITLE
Revert "Permit comment after other input on the line (#119)"

### DIFF
--- a/fleprocess/load_file.go
+++ b/fleprocess/load_file.go
@@ -53,7 +53,6 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 	isInferTimeFatalError := false
 
 	regexpLineComment := regexp.MustCompile(`^[[:blank:]]*#`)
-	regexpInLineComment := regexp.MustCompile(`.*#.*`)
 	regexpOnlySpaces := regexp.MustCompile(`^\s+$`)
 	regexpSingleMultiLineComment := regexp.MustCompile(`^[[:blank:]]*{.+}$`)
 	regexpStartMultiLineComment := regexp.MustCompile(`^[[:blank:]]*{`)
@@ -104,10 +103,6 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 		//Skip if line is empty or blank
 		if (len(eachline) == 0) || (regexpOnlySpaces.MatchString(eachline)) {
 			continue
-		}
-		// a comment starts somewhere on the line, remove the comment
-		if regexpInLineComment.MatchString(eachline) {
-			eachline = strings.Split(eachline, "#")[0]
 		}
 
 		// Process multi-line comments

--- a/fleprocess/load_file_test.go
+++ b/fleprocess/load_file_test.go
@@ -49,7 +49,6 @@ func TestLoadFile_happyCase(t *testing.T) {
 	dataArray = append(dataArray, "40m cw 0950 ik5zve/5 9 5")
 	dataArray = append(dataArray, "on6zq")
 	dataArray = append(dataArray, "0954 on4do")
-	dataArray = append(dataArray, "0955 k0emt # on line comment")
 
 	temporaryDataFileName := createTestFile(dataArray)
 
@@ -115,14 +114,6 @@ func TestLoadFile_happyCase(t *testing.T) {
 	expectedValue = "0954"
 	if loadedLogFile[2].Time != expectedValue {
 		t.Errorf("Not the expected Time[2] value: %s (expecting %s)", loadedLogFile[2].Time, expectedValue)
-	}
-	expectedValue = "K0EMT"
-	if loadedLogFile[3].Call != expectedValue {
-		t.Errorf("Not the expected Call[3] value: %s (expecting %s)", loadedLogFile[3].Call, expectedValue)
-	}
-	expectedValue = "0955"
-	if loadedLogFile[3].Time != expectedValue {
-		t.Errorf("Not the expected Time[3] value: %s (expecting %s)", loadedLogFile[3].Time, expectedValue)
 	}
 	//Clean Up
 	os.Remove(temporaryDataFileName)


### PR DESCRIPTION
This reverts commit caefd4699441244e8e469df04a402e3df8cc4497.
I went back and reviewed this again.  _I goofed._  What I was observing is not the documented intended behavior.

According to the [FLE documentation](https://df3cb.com/fle/documentation/#other) for a comment the # must be in the first position on the line.  However, as implemented it permits whitespace before the # (still must be the first non-whitespace character).

The # operator is overloaded.  If the # occurs in any other position in the line, it should be used to indicate a Grid Square.