### PR TITLE
Add chronological sorting for ADIF exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ The `-o` or `--overwrite` flag indicates that, if the output file already exists
 
 The `-i` or `--interpolate` flag will interpolate the missing non-entered times based on the first and the last entered time.
 
+The optional `--sort` flag stably sorts the generated ADIF QSO records by date
+and time without changing the FLE input file. QSOs with identical dates and
+times retain their original relative order. When an input contains time
+reversals and `--sort` is not used, FLEcli prints a warning.
+
+```shell
+./FLEcli adif --sota --sort --overwrite activation.txt output/activation.adi
+```
+
 ### Example: generate an ADIF file for WWFF upload
 
 To generate a WWFF-ready ADIF file:

--- a/README.md
+++ b/README.md
@@ -73,13 +73,15 @@ The `-o` or `--overwrite` flag indicates that, if the output file already exists
 
 The `-i` or `--interpolate` flag will interpolate the missing non-entered times based on the first and the last entered time.
 
-The optional `--sort` flag stably sorts the generated ADIF QSO records by date
-and time without changing the FLE input file. QSOs with identical dates and
-times retain their original relative order. When an input contains time
-reversals and `--sort` is not used, FLEcli prints a warning.
+SOTA-ready exports are automatically sorted by date and time because the SOTA
+importer requires chronological records. The optional `--sort` flag enables the
+same stable sorting for other ADIF exports without changing the FLE input file.
+QSOs with identical dates and times retain their original relative order. When
+an input contains time reversals and neither `--sota` nor `--sort` is used,
+FLEcli prints a warning.
 
 ```shell
-./FLEcli adif --sota --sort --overwrite activation.txt output/activation.adi
+./FLEcli adif --sota --overwrite activation.txt output/activation.adi
 ```
 
 ### Example: generate an ADIF file for WWFF upload

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -52,7 +52,7 @@ Flags:
   -o, --overwrite     Overwrites the output file if it exisits
   -p, --pota          Generates a POTA ready ADIF file.
   -s, --sota          Generates a SOTA ready ADIF file.
-      --sort          Sorts ADIF QSO records chronologically by date and time.
+      --sort          Sorts ADIF QSO records chronologically by date and time (automatic with --sota).
   -w, --wwff          Generates a WWFF ready ADIF file.
 
 Global Flags:

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -52,6 +52,7 @@ Flags:
   -o, --overwrite     Overwrites the output file if it exisits
   -p, --pota          Generates a POTA ready ADIF file.
   -s, --sota          Generates a SOTA ready ADIF file.
+      --sort          Sorts ADIF QSO records chronologically by date and time.
   -w, --wwff          Generates a WWFF ready ADIF file.
 
 Global Flags:

--- a/flecmd/adif.go
+++ b/flecmd/adif.go
@@ -29,6 +29,7 @@ var isWWFFcli bool
 var isSOTAcli bool
 var isPOTAcli bool
 var isOverwrite bool
+var isSortChronological bool
 
 // adifCmd is executed when choosing the adif option (load and generate adif file)
 var adifCmd = &cobra.Command{
@@ -68,6 +69,7 @@ var adifCmd = &cobra.Command{
 		adifParam.IsPOTA = isPOTAcli
 		adifParam.IsWWFF = isWWFFcli
 		adifParam.IsOverwrite = isOverwrite
+		adifParam.IsSortChronological = isSortChronological
 
 		err := fleprocess.ProcessAdifCommand(*adifParam)
 		if err != nil {
@@ -88,4 +90,5 @@ func init() {
 	adifCmd.PersistentFlags().BoolVarP(&isSOTAcli, "sota", "s", false, "Generates a SOTA ready ADIF file.")
 	adifCmd.PersistentFlags().BoolVarP(&isPOTAcli, "pota", "p", false, "Generates a POTA ready ADIF file.")
 	adifCmd.PersistentFlags().BoolVarP(&isOverwrite, "overwrite", "o", false, "Overwrites the output file if it exisits")
+	adifCmd.PersistentFlags().BoolVar(&isSortChronological, "sort", false, "Sorts ADIF QSO records chronologically by date and time.")
 }

--- a/flecmd/adif.go
+++ b/flecmd/adif.go
@@ -90,5 +90,5 @@ func init() {
 	adifCmd.PersistentFlags().BoolVarP(&isSOTAcli, "sota", "s", false, "Generates a SOTA ready ADIF file.")
 	adifCmd.PersistentFlags().BoolVarP(&isPOTAcli, "pota", "p", false, "Generates a POTA ready ADIF file.")
 	adifCmd.PersistentFlags().BoolVarP(&isOverwrite, "overwrite", "o", false, "Overwrites the output file if it exisits")
-	adifCmd.PersistentFlags().BoolVar(&isSortChronological, "sort", false, "Sorts ADIF QSO records chronologically by date and time.")
+	adifCmd.PersistentFlags().BoolVar(&isSortChronological, "sort", false, "Sorts ADIF QSO records chronologically by date and time (automatic with --sota).")
 }

--- a/fleprocess/adif_process.go
+++ b/fleprocess/adif_process.go
@@ -59,7 +59,10 @@ func ProcessAdifCommand(adifParams AdifParams) error {
 		return err
 	}
 
-	if adifParams.IsSortChronological {
+	// SOTA importers require QSOs to be chronological, so SOTA-ready exports
+	// always sort. The explicit flag makes the same behavior available to the
+	// other ADIF export formats.
+	if adifParams.IsSOTA || adifParams.IsSortChronological {
 		reorderedRecords := sortLogChronologically(loadedLogFile)
 		if reorderedRecords > 0 {
 			fmt.Printf("\nSorted %d QSO record(s) chronologically.\n", reorderedRecords)

--- a/fleprocess/adif_process.go
+++ b/fleprocess/adif_process.go
@@ -24,13 +24,14 @@ import (
 
 // AdifParams is holding all the parameters required to generate an ADIF file
 type AdifParams struct {
-	InputFilename     string
-	OutputFilename    string
-	IsInterpolateTime bool
-	IsWWFF            bool
-	IsSOTA            bool
-	IsPOTA            bool
-	IsOverwrite       bool
+	InputFilename       string
+	OutputFilename      string
+	IsInterpolateTime   bool
+	IsWWFF              bool
+	IsSOTA              bool
+	IsPOTA              bool
+	IsOverwrite         bool
+	IsSortChronological bool
 }
 
 // ProcessAdifCommand loads an FLE input to produce an adif file (eventually in WWFF format). It is called from the COBRA interface
@@ -56,6 +57,15 @@ func ProcessAdifCommand(adifParams AdifParams) error {
 	//Check if we have all the necessary data
 	if err := validateDataforAdif(loadedLogFile, adifParams); err != nil {
 		return err
+	}
+
+	if adifParams.IsSortChronological {
+		reorderedRecords := sortLogChronologically(loadedLogFile)
+		if reorderedRecords > 0 {
+			fmt.Printf("\nSorted %d QSO record(s) chronologically.\n", reorderedRecords)
+		}
+	} else if reversals := countChronologicalReversals(loadedLogFile); reversals > 0 {
+		fmt.Printf("\nWarning: detected %d out-of-order QSO transition(s). Use --sort to generate chronologically ordered ADIF records.\n", reversals)
 	}
 
 	//Write the output file with the checked data
@@ -115,31 +125,31 @@ func validateDataforAdif(loadedLogFile []LogLine, adifParams AdifParams) error {
 			if errorsBuffer.String() != "" {
 				errorsBuffer.WriteString(", ")
 			}
-			fmt.Fprintf(&errorsBuffer,"missing date %s", errorLocation)
+			fmt.Fprintf(&errorsBuffer, "missing date %s", errorLocation)
 		}
 		if loadedLogFile[i].Band == "" {
 			if errorsBuffer.String() != "" {
 				errorsBuffer.WriteString(", ")
 			}
-			fmt.Fprintf(&errorsBuffer,"missing band %s", errorLocation)
+			fmt.Fprintf(&errorsBuffer, "missing band %s", errorLocation)
 		}
 		if loadedLogFile[i].Mode == "" {
 			if errorsBuffer.String() != "" {
 				errorsBuffer.WriteString(", ")
 			}
-			fmt.Fprintf(&errorsBuffer,"missing mode %s", errorLocation)
+			fmt.Fprintf(&errorsBuffer, "missing mode %s", errorLocation)
 		}
 		if loadedLogFile[i].Call == "" {
 			if errorsBuffer.String() != "" {
 				errorsBuffer.WriteString(", ")
 			}
-			fmt.Fprintf(&errorsBuffer,"missing call %s", errorLocation)
+			fmt.Fprintf(&errorsBuffer, "missing call %s", errorLocation)
 		}
 		if loadedLogFile[i].Time == "" {
 			if errorsBuffer.String() != "" {
 				errorsBuffer.WriteString(", ")
 			}
-			fmt.Fprintf(&errorsBuffer,"missing QSO time %s", errorLocation)
+			fmt.Fprintf(&errorsBuffer, "missing QSO time %s", errorLocation)
 		}
 	}
 	if errorsBuffer.String() != "" {

--- a/fleprocess/adif_process_test.go
+++ b/fleprocess/adif_process_test.go
@@ -2,6 +2,9 @@ package fleprocess
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -147,6 +150,40 @@ func Test_validateDataforAdif2(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestProcessAdifCommandSortsChronologically(t *testing.T) {
+	outputFilename := filepath.Join(t.TempDir(), "sorted.adi")
+	adifParams := AdifParams{
+		InputFilename:       "../test/data/fle-adif-sort.txt",
+		OutputFilename:      outputFilename,
+		IsSOTA:              true,
+		IsSortChronological: true,
+	}
+
+	if err := ProcessAdifCommand(adifParams); err != nil {
+		t.Fatalf("ProcessAdifCommand() error = %v", err)
+	}
+
+	output, err := os.ReadFile(outputFilename)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+
+	adif := string(output)
+	positions := []int{
+		strings.Index(adif, "<TIME_ON:4>2149"),
+		strings.Index(adif, "<TIME_ON:4>2151"),
+		strings.Index(adif, "<TIME_ON:4>2153"),
+	}
+	for i, position := range positions {
+		if position == -1 {
+			t.Fatalf("sorted ADIF is missing expected time at index %d", i)
+		}
+		if i > 0 && position <= positions[i-1] {
+			t.Fatalf("ADIF times are not chronological: positions = %v", positions)
+		}
 	}
 }
 

--- a/fleprocess/adif_process_test.go
+++ b/fleprocess/adif_process_test.go
@@ -153,13 +153,12 @@ func Test_validateDataforAdif2(t *testing.T) {
 	}
 }
 
-func TestProcessAdifCommandSortsChronologically(t *testing.T) {
+func TestProcessAdifCommandSortsSOTAChronologicallyByDefault(t *testing.T) {
 	outputFilename := filepath.Join(t.TempDir(), "sorted.adi")
 	adifParams := AdifParams{
-		InputFilename:       "../test/data/fle-adif-sort.txt",
-		OutputFilename:      outputFilename,
-		IsSOTA:              true,
-		IsSortChronological: true,
+		InputFilename:  "../test/data/fle-adif-sort.txt",
+		OutputFilename: outputFilename,
+		IsSOTA:         true,
 	}
 
 	if err := ProcessAdifCommand(adifParams); err != nil {

--- a/fleprocess/adif_sort.go
+++ b/fleprocess/adif_sort.go
@@ -1,0 +1,67 @@
+package fleprocess
+
+/*
+Copyright © 2026 Jean-Marc Meessen, ON4KJM <on4kjm@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import "sort"
+
+// countChronologicalReversals counts adjacent QSO transitions where the date
+// and time move backwards.
+func countChronologicalReversals(fullLog []LogLine) int {
+	reversals := 0
+	for i := 1; i < len(fullLog); i++ {
+		if logLineChronologicallyLess(fullLog[i], fullLog[i-1]) {
+			reversals++
+		}
+	}
+	return reversals
+}
+
+// sortLogChronologically stably sorts QSOs by date and time. It returns the
+// number of records whose position changed. Stable sorting preserves the input
+// order of QSOs with identical dates and times.
+func sortLogChronologically(fullLog []LogLine) int {
+	type indexedLogLine struct {
+		logLine       LogLine
+		originalIndex int
+	}
+
+	indexedLog := make([]indexedLogLine, len(fullLog))
+	for i, logLine := range fullLog {
+		indexedLog[i] = indexedLogLine{logLine: logLine, originalIndex: i}
+	}
+
+	sort.SliceStable(indexedLog, func(i, j int) bool {
+		return logLineChronologicallyLess(indexedLog[i].logLine, indexedLog[j].logLine)
+	})
+
+	reorderedRecords := 0
+	for i, item := range indexedLog {
+		if item.originalIndex != i {
+			reorderedRecords++
+		}
+		fullLog[i] = item.logLine
+	}
+
+	return reorderedRecords
+}
+
+func logLineChronologicallyLess(left, right LogLine) bool {
+	if left.Date != right.Date {
+		return left.Date < right.Date
+	}
+	return left.Time < right.Time
+}

--- a/fleprocess/adif_sort_test.go
+++ b/fleprocess/adif_sort_test.go
@@ -1,0 +1,53 @@
+package fleprocess
+
+/*
+Copyright © 2026 Jean-Marc Meessen, ON4KJM <on4kjm@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import "testing"
+
+func TestCountChronologicalReversals(t *testing.T) {
+	fullLog := []LogLine{
+		{Date: "2026-08-01", Time: "2011"},
+		{Date: "2026-08-01", Time: "2010"},
+		{Date: "2026-08-01", Time: "2013"},
+		{Date: "2026-08-01", Time: "2119"},
+		{Date: "2026-08-01", Time: "2115"},
+	}
+
+	if got, want := countChronologicalReversals(fullLog), 2; got != want {
+		t.Fatalf("countChronologicalReversals() = %d, want %d", got, want)
+	}
+}
+
+func TestSortLogChronologicallyIsStable(t *testing.T) {
+	fullLog := []LogLine{
+		{Date: "2026-08-01", Time: "2151", Call: "AE6Z"},
+		{Date: "2026-08-01", Time: "2149", Call: "NW7E"},
+		{Date: "2026-08-01", Time: "2151", Call: "SAME1"},
+		{Date: "2026-07-31", Time: "2359", Call: "PREVIOUS"},
+	}
+
+	if got, want := sortLogChronologically(fullLog), 3; got != want {
+		t.Fatalf("sortLogChronologically() reordered %d records, want %d", got, want)
+	}
+
+	wantCalls := []string{"PREVIOUS", "NW7E", "AE6Z", "SAME1"}
+	for i, want := range wantCalls {
+		if got := fullLog[i].Call; got != want {
+			t.Errorf("fullLog[%d].Call = %q, want %q", i, got, want)
+		}
+	}
+}

--- a/test/data/fle-adif-sort.txt
+++ b/test/data/fle-adif-sort.txt
@@ -1,0 +1,9 @@
+mycall AB1WX
+mysota W1/CR-001
+date 2026-08-01
+cw
+17m
+18.093
+2151 AE6Z 3 4
+49 NW7E 5 5
+53 KG0AT 3 3


### PR DESCRIPTION
## Summary

- sort SOTA-ready ADIF exports chronologically by date and time automatically
- add an opt-in FLEcli adif --sort flag for POTA, WWFF, and general ADIF exports
- preserve source order for records with identical timestamps and never modify the FLE input file
- warn when an unsorted non-SOTA export contains backward date/time transitions
- document the behavior and add unit plus end-to-end coverage

## Motivation

The SOTA importer requires ADIF records to be chronological, so the program-specific --sota option now guarantees importer-compatible ordering without an additional flag. FLE shorthand can legitimately produce out-of-order timestamps when a handwritten multi-band activation is transcribed in page order. Other export types retain their existing order unless --sort is requested.

## Validation

- go test ./...
- go test -race -count=1 ./...
- go vet ./...
- manual end-to-end test on a real-world multi-band activation file