### PR TITLE
Add logging station location directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,39 @@ The `-o` or `--overwrite` flag indicates that, if the output file already exists
 
 The `-i` or `--interpolate` flag will interpolate the missing non-entered times based on the first and the last entered time.
 
+#### Logging-station location directives
+
+Optional header directives can describe the physical location of the logging
+station. Their values are copied to every QSO record using the corresponding
+ADIF `MY_*` fields.
+
+| FLE directive | ADIF field | Value |
+| --- | --- | --- |
+| `mygrid` | `MY_GRIDSQUARE` | Maidenhead grid locator |
+| `mylat` | `MY_LAT` | latitude in decimal degrees |
+| `mylon` | `MY_LON` | longitude in decimal degrees |
+| `myaltitude` | `MY_ALTITUDE` | meters above mean sea level |
+| `mycity` | `MY_CITY` | city or municipality |
+| `mycounty` | `MY_CNTY` | ADIF secondary subdivision |
+| `mystate` | `MY_STATE` | ADIF primary subdivision code |
+| `mycountry` | `MY_COUNTRY` | ADIF DXCC entity name |
+| `mydxcc` | `MY_DXCC` | numeric ADIF DXCC entity code |
+
+For United States counties, `mycounty` uses `STATE,County` format and must
+agree with `mystate`. For example:
+
+```text
+mygrid      FN42bl
+mylat       42.4891
+mylon       -71.8865
+myaltitude  611
+mycity      Princeton
+mystate     MA
+mycountry   United States
+mydxcc      291
+mycounty    MA,Worcester
+```
+
 ### Example: generate an ADIF file for WWFF upload
 
 To generate a WWFF-ready ADIF file:

--- a/fleprocess/adif_process_test.go
+++ b/fleprocess/adif_process_test.go
@@ -2,6 +2,9 @@ package fleprocess
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -214,5 +217,34 @@ func TestProcessAdifCommand(t *testing.T) {
 				t.Errorf("ProcessAdifCommand() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestProcessAdifCommandExportsStationLocation(t *testing.T) {
+	outputFilename := filepath.Join(t.TempDir(), "location.adi")
+	if err := ProcessAdifCommand(AdifParams{
+		InputFilename:  "../test/data/fle-adif-location.txt",
+		OutputFilename: outputFilename,
+	}); err != nil {
+		t.Fatalf("ProcessAdifCommand() error = %v", err)
+	}
+
+	output, err := os.ReadFile(outputFilename)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+
+	wantedFields := []string{
+		"<MY_ALTITUDE:3>611",
+		"<MY_CITY:9>Princeton",
+		"<MY_CNTY:12>MA,Worcester",
+		"<MY_STATE:2>MA",
+		"<MY_COUNTRY:13>United States",
+		"<MY_DXCC:3>291",
+	}
+	for _, wantedField := range wantedFields {
+		if !strings.Contains(string(output), wantedField) {
+			t.Errorf("ADIF output is missing %q", wantedField)
+		}
 	}
 }

--- a/fleprocess/adif_write.go
+++ b/fleprocess/adif_write.go
@@ -37,7 +37,7 @@ func buildAdif(fullLog []LogLine, adifParams AdifParams) (adifList []string) {
 	//Print the fixed header
 	adifList = append(adifList, "ADIF Export for Fast Log Entry CLI by ON4KJM")
 	adifList = append(adifList, "<PROGRAMID:6>FLEcli")
-	adifList = append(adifList, "<ADIF_VER:5>3.1.0")
+	adifList = append(adifList, "<ADIF_VER:5>3.1.7")
 	adifList = append(adifList, "<EOH>")
 
 	for _, logLine := range fullLog {
@@ -100,8 +100,23 @@ func buildAdif(fullLog []LogLine, adifParams AdifParams) (adifList []string) {
 		if logLine.MyLon != "" {
 			adifLine.WriteString(adifElement("MY_LON", logLine.MyLon))
 		}
+		if logLine.MyAltitude != "" {
+			adifLine.WriteString(adifElement("MY_ALTITUDE", logLine.MyAltitude))
+		}
+		if logLine.MyCity != "" {
+			adifLine.WriteString(adifElement("MY_CITY", logLine.MyCity))
+		}
 		if logLine.MyCounty != "" {
 			adifLine.WriteString(adifElement("MY_CNTY", logLine.MyCounty))
+		}
+		if logLine.MyState != "" {
+			adifLine.WriteString(adifElement("MY_STATE", logLine.MyState))
+		}
+		if logLine.MyCountry != "" {
+			adifLine.WriteString(adifElement("MY_COUNTRY", logLine.MyCountry))
+		}
+		if logLine.MyDXCC != "" {
+			adifLine.WriteString(adifElement("MY_DXCC", logLine.MyDXCC))
 		}
 		if logLine.Nickname != "" {
 			adifLine.WriteString(adifElement("APP_EQSL_QTH_NICKNAME", logLine.Nickname))

--- a/fleprocess/adif_write_test.go
+++ b/fleprocess/adif_write_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -51,6 +52,44 @@ func Test_adifElement(t *testing.T) {
 	}
 }
 
+func TestBuildAdifIncludesStationLocationFields(t *testing.T) {
+	fullLog := []LogLine{{
+		MyCall:     "AB1WX",
+		Call:       "K1ABC",
+		Date:       "2026-08-01",
+		Time:       "2000",
+		Band:       "20m",
+		Mode:       "CW",
+		RSTsent:    "599",
+		RSTrcvd:    "599",
+		MyAltitude: "611",
+		MyCity:     "Princeton",
+		MyCounty:   "MA,Worcester",
+		MyState:    "MA",
+		MyCountry:  "United States",
+		MyDXCC:     "291",
+	}}
+
+	output := buildAdif(fullLog, AdifParams{})
+	if len(output) != 5 {
+		t.Fatalf("buildAdif() returned %d lines, want 5", len(output))
+	}
+
+	wantedFields := []string{
+		"<MY_ALTITUDE:3>611",
+		"<MY_CITY:9>Princeton",
+		"<MY_CNTY:12>MA,Worcester",
+		"<MY_STATE:2>MA",
+		"<MY_COUNTRY:13>United States",
+		"<MY_DXCC:3>291",
+	}
+	for _, wantedField := range wantedFields {
+		if !strings.Contains(output[4], wantedField) {
+			t.Errorf("ADIF record is missing %q: %s", wantedField, output[4])
+		}
+	}
+}
+
 func Test_buildAdif(t *testing.T) {
 	sampleFilledLog1 := []LogLine{
 		{MyCall: "ON4KJM/P", Call: "S57LC", Date: "2020-05-24", Time: "1310", Band: "20m", Frequency: "14.045", Mode: "CW", RSTsent: "599", RSTrcvd: "599", MyWWFF: "ONFF-0259", Operator: "ON4KJM", Nickname: "ONFF-0259-1"},
@@ -58,7 +97,7 @@ func Test_buildAdif(t *testing.T) {
 	}
 	expectedADIFtitle := "ADIF Export for Fast Log Entry CLI by ON4KJM"
 	expectedADIFprogramId := "<PROGRAMID:6>FLEcli"
-	expectedADIFversion := "<ADIF_VER:5>3.1.0"
+	expectedADIFversion := "<ADIF_VER:5>3.1.7"
 
 	expectedOutput1 := []string{
 		expectedADIFtitle,

--- a/fleprocess/displayLog.go
+++ b/fleprocess/displayLog.go
@@ -87,8 +87,28 @@ func SprintHeaderValues(logLine LogLine) string {
 		output.WriteString("MyLon     " + logLine.MyLon + "\n")
 	}
 
+	if logLine.MyAltitude != "" {
+		output.WriteString("MyAltitude " + logLine.MyAltitude + "\n")
+	}
+
+	if logLine.MyCity != "" {
+		output.WriteString("MyCity    " + logLine.MyCity + "\n")
+	}
+
 	if logLine.MyCounty != "" {
 		output.WriteString("MyCounty  " + logLine.MyCounty + "\n")
+	}
+
+	if logLine.MyState != "" {
+		output.WriteString("MyState   " + logLine.MyState + "\n")
+	}
+
+	if logLine.MyCountry != "" {
+		output.WriteString("MyCountry " + logLine.MyCountry + "\n")
+	}
+
+	if logLine.MyDXCC != "" {
+		output.WriteString("MyDXCC    " + logLine.MyDXCC + "\n")
 	}
 
 	return output.String()
@@ -101,8 +121,8 @@ var logLineFormat = "%-10s %-4s %-4s %-4s %-12s %-4s %-4s %s\n"
 func SprintColumnTitles() string {
 	var output strings.Builder
 	//output.WriteString(fmt.Sprintf(logLineFormat, "Date", "Time", "Band", "Mode", "Call", "Sent", "Rcvd", "Notes"))
-	fmt.Fprintf(&output,logLineFormat, "Date", "Time", "Band", "Mode", "Call", "Sent", "Rcvd", "Notes")
-	fmt.Fprintf(&output,logLineFormat, "----", "----", "----", "----", "----", "----", "----", "----")
+	fmt.Fprintf(&output, logLineFormat, "Date", "Time", "Band", "Mode", "Call", "Sent", "Rcvd", "Notes")
+	fmt.Fprintf(&output, logLineFormat, "----", "----", "----", "----", "----", "----", "----", "----")
 	return output.String()
 }
 

--- a/fleprocess/load_file.go
+++ b/fleprocess/load_file.go
@@ -68,7 +68,12 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 	regexpHeaderMyGrid := regexp.MustCompile(`(?i)^mygrid\s+`)
 	regexpHeaderMyLat := regexp.MustCompile(`(?i)^mylat\s+`)
 	regexpHeaderMyLon := regexp.MustCompile(`(?i)^mylon\s+`)
+	regexpHeaderMyAltitude := regexp.MustCompile(`(?i)^myaltitude\s+`)
+	regexpHeaderMyCity := regexp.MustCompile(`(?i)^mycity\s+`)
 	regexpHeaderMyCounty := regexp.MustCompile(`(?i)^mycounty\s+`)
+	regexpHeaderMyState := regexp.MustCompile(`(?i)^mystate\s+`)
+	regexpHeaderMyCountry := regexp.MustCompile(`(?i)^mycountry\s+`)
+	regexpHeaderMyDXCC := regexp.MustCompile(`(?i)^mydxcc\s+`)
 	regexpHeaderQslMsg := regexp.MustCompile(`(?i)^qslmsg\s+`)
 	regexpHeaderNickname := regexp.MustCompile(`(?i)^nickname\s+`)
 
@@ -80,7 +85,13 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 	headerMyGrid := ""
 	headerMyLat := ""
 	headerMyLon := ""
+	headerMyAltitude := ""
+	headerMyCity := ""
 	headerMyCounty := ""
+	headerMyCountyLine := 0
+	headerMyState := ""
+	headerMyCountry := ""
+	headerMyDXCC := ""
 	headerQslMsg := ""
 	headerNickname := ""
 	//headerDate := ""
@@ -291,11 +302,89 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 			continue
 		}
 
+		//My Altitude
+		if regexpHeaderMyAltitude.MatchString(eachline) {
+			if headerMyAltitude != "" {
+				errorLog = append(errorLog, fmt.Sprintf("Attempt to redefine MyAltitude at line %d", lineCount))
+				continue
+			}
+			errorMsg := ""
+			myAltitudeList := regexpHeaderMyAltitude.Split(eachline, -1)
+			if len(strings.TrimSpace(myAltitudeList[1])) > 0 {
+				headerMyAltitude, errorMsg = ValidateAltitude(myAltitudeList[1])
+				if len(errorMsg) != 0 {
+					errorLog = append(errorLog, fmt.Sprintf("Invalid \"My Altitude\" at line %d: %s (%s)", lineCount, myAltitudeList[1], errorMsg))
+				}
+			}
+			continue
+		}
+
+		//My City
+		if regexpHeaderMyCity.MatchString(eachline) {
+			if headerMyCity != "" {
+				errorLog = append(errorLog, fmt.Sprintf("Attempt to redefine MyCity at line %d", lineCount))
+				continue
+			}
+			myCityList := regexpHeaderMyCity.Split(eachline, -1)
+			if len(strings.TrimSpace(myCityList[1])) > 0 {
+				headerMyCity = strings.TrimSpace(myCityList[1])
+			}
+			continue
+		}
+
+		//My State
+		if regexpHeaderMyState.MatchString(eachline) {
+			if headerMyState != "" {
+				errorLog = append(errorLog, fmt.Sprintf("Attempt to redefine MyState at line %d", lineCount))
+				continue
+			}
+			myStateList := regexpHeaderMyState.Split(eachline, -1)
+			if len(strings.TrimSpace(myStateList[1])) > 0 {
+				headerMyState = strings.ToUpper(strings.TrimSpace(myStateList[1]))
+			}
+			continue
+		}
+
+		//My Country
+		if regexpHeaderMyCountry.MatchString(eachline) {
+			if headerMyCountry != "" {
+				errorLog = append(errorLog, fmt.Sprintf("Attempt to redefine MyCountry at line %d", lineCount))
+				continue
+			}
+			myCountryList := regexpHeaderMyCountry.Split(eachline, -1)
+			if len(strings.TrimSpace(myCountryList[1])) > 0 {
+				headerMyCountry = strings.TrimSpace(myCountryList[1])
+			}
+			continue
+		}
+
+		//My DXCC
+		if regexpHeaderMyDXCC.MatchString(eachline) {
+			if headerMyDXCC != "" {
+				errorLog = append(errorLog, fmt.Sprintf("Attempt to redefine MyDXCC at line %d", lineCount))
+				continue
+			}
+			errorMsg := ""
+			myDXCCList := regexpHeaderMyDXCC.Split(eachline, -1)
+			if len(strings.TrimSpace(myDXCCList[1])) > 0 {
+				headerMyDXCC, errorMsg = ValidateDXCC(myDXCCList[1])
+				if len(errorMsg) != 0 {
+					errorLog = append(errorLog, fmt.Sprintf("Invalid \"My DXCC\" at line %d: %s (%s)", lineCount, myDXCCList[1], errorMsg))
+				}
+			}
+			continue
+		}
+
 		//My County
 		if regexpHeaderMyCounty.MatchString(eachline) {
+			if headerMyCounty != "" {
+				errorLog = append(errorLog, fmt.Sprintf("Attempt to redefine MyCounty at line %d", lineCount))
+				continue
+			}
 			myMyCountyList := regexpHeaderMyCounty.Split(eachline, -1)
-			if len(myMyCountyList[1]) > 0 {
-				headerMyCounty = myMyCountyList[1]
+			if len(strings.TrimSpace(myMyCountyList[1])) > 0 {
+				headerMyCounty = strings.TrimSpace(myMyCountyList[1])
+				headerMyCountyLine = lineCount
 			}
 			//If there is no data after the marker, we just skip the data.
 			continue
@@ -341,7 +430,12 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 		previousLogLine.MyGrid = headerMyGrid
 		previousLogLine.MyLat = headerMyLat
 		previousLogLine.MyLon = headerMyLon
+		previousLogLine.MyAltitude = headerMyAltitude
+		previousLogLine.MyCity = headerMyCity
 		previousLogLine.MyCounty = headerMyCounty
+		previousLogLine.MyState = headerMyState
+		previousLogLine.MyCountry = headerMyCountry
+		previousLogLine.MyDXCC = headerMyDXCC
 		previousLogLine.QSLmsg = headerQslMsg //previousLogLine.QslMsg is redundant
 		previousLogLine.Nickname = headerNickname
 
@@ -402,6 +496,16 @@ func LoadFile(inputFilename string, isInterpolateTime bool) (filleFullLog []LogL
 	//***
 	//*** We have done processing the log file, so let's post process it
 	//***
+	if headerMyCounty != "" {
+		validatedCounty, errorMsg := ValidateCounty(headerMyCounty, headerMyDXCC, headerMyState)
+		if errorMsg != "" {
+			errorLog = append(errorLog, fmt.Sprintf("Invalid \"My County\" at line %d: %s (%s)", headerMyCountyLine, headerMyCounty, errorMsg))
+		} else if validatedCounty != headerMyCounty {
+			for i := range fullLog {
+				fullLog[i].MyCounty = validatedCounty
+			}
+		}
+	}
 
 	//if asked to infer the date, lets update the loaded logfile accordingly
 	if isInterpolateTime {

--- a/fleprocess/load_file_test.go
+++ b/fleprocess/load_file_test.go
@@ -44,7 +44,12 @@ func TestLoadFile_happyCase(t *testing.T) {
 	dataArray = append(dataArray, "myGrid jo50")
 	dataArray = append(dataArray, "myLat 55.5555555")
 	dataArray = append(dataArray, "myLon -120.01234567")
-	dataArray = append(dataArray, "myCounty Ham County")
+	dataArray = append(dataArray, "myAltitude 611")
+	dataArray = append(dataArray, "myCity Princeton")
+	dataArray = append(dataArray, "myCounty ma,Worcester")
+	dataArray = append(dataArray, "myState ma")
+	dataArray = append(dataArray, "myCountry United States")
+	dataArray = append(dataArray, "myDXCC 291")
 	dataArray = append(dataArray, "QslMsg This is a QSL message")
 	dataArray = append(dataArray, " ")
 	dataArray = append(dataArray, " #Log")
@@ -94,11 +99,31 @@ func TestLoadFile_happyCase(t *testing.T) {
 	if loadedLogFile[0].MyLon != expectedValue {
 		t.Errorf("Not the expected MyLon value: %s (expecting %s)", loadedLogFile[0].MyLon, expectedValue)
 	}
+	expectedValue = "611"
+	if loadedLogFile[0].MyAltitude != expectedValue {
+		t.Errorf("Not the expected MyAltitude value: %s (expecting %s)", loadedLogFile[0].MyAltitude, expectedValue)
+	}
+	expectedValue = "Princeton"
+	if loadedLogFile[0].MyCity != expectedValue {
+		t.Errorf("Not the expected MyCity value: %s (expecting %s)", loadedLogFile[0].MyCity, expectedValue)
+	}
+	expectedValue = "MA"
+	if loadedLogFile[0].MyState != expectedValue {
+		t.Errorf("Not the expected MyState value: %s (expecting %s)", loadedLogFile[0].MyState, expectedValue)
+	}
+	expectedValue = "United States"
+	if loadedLogFile[0].MyCountry != expectedValue {
+		t.Errorf("Not the expected MyCountry value: %s (expecting %s)", loadedLogFile[0].MyCountry, expectedValue)
+	}
+	expectedValue = "291"
+	if loadedLogFile[0].MyDXCC != expectedValue {
+		t.Errorf("Not the expected MyDXCC value: %s (expecting %s)", loadedLogFile[0].MyDXCC, expectedValue)
+	}
 	expectedValue = "This is a QSL message"
 	if loadedLogFile[0].QSLmsg != expectedValue {
 		t.Errorf("Not the expected QSL Message from Header value: %s (expecting %s)", loadedLogFile[0].QSLmsg, expectedValue)
 	}
-	expectedValue = "Ham County"
+	expectedValue = "MA,Worcester"
 	if loadedLogFile[0].MyCounty != expectedValue {
 		t.Errorf("Not the expected MyCounty from Header value: %s (expecting %s)", loadedLogFile[0].MyCounty, expectedValue)
 	}

--- a/fleprocess/parse_line.go
+++ b/fleprocess/parse_line.go
@@ -36,7 +36,12 @@ type LogLine struct {
 	MyGrid           string
 	MyLat            string
 	MyLon            string
+	MyAltitude       string
+	MyCity           string
 	MyCounty         string
+	MyState          string
+	MyCountry        string
+	MyDXCC           string
 	QslMsgFromHeader string
 	Nickname         string
 	Mode             string

--- a/fleprocess/validate.go
+++ b/fleprocess/validate.go
@@ -18,6 +18,7 @@ limitations under the License.
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -46,6 +47,57 @@ func ValidateLon(lon string) (ref, errorMsg string) {
 
 	errorMsg = "[" + lon + "] is an invalid lon"
 	return "*" + lon, errorMsg
+}
+
+// ValidateAltitude checks that a station altitude is a finite number of meters
+// relative to mean sea level.
+func ValidateAltitude(altitude string) (ref, errorMsg string) {
+	altitude = strings.TrimSpace(altitude)
+	if value, err := strconv.ParseFloat(altitude, 64); err == nil && !math.IsNaN(value) && !math.IsInf(value, 0) {
+		return altitude, ""
+	}
+
+	errorMsg = "[" + altitude + "] is an invalid altitude"
+	return "*" + altitude, errorMsg
+}
+
+// ValidateDXCC checks that a logging station DXCC entity code is a
+// non-negative integer. Zero means that the station is known not to be within
+// a DXCC entity.
+func ValidateDXCC(dxcc string) (ref, errorMsg string) {
+	dxcc = strings.TrimSpace(dxcc)
+	if value, err := strconv.Atoi(dxcc); err == nil && value >= 0 {
+		return strconv.Itoa(value), ""
+	}
+
+	errorMsg = "[" + dxcc + "] is an invalid DXCC entity code"
+	return "*" + dxcc, errorMsg
+}
+
+var validUSCountyRegexp = regexp.MustCompile(`^([A-Za-z]{2}),([^,]+)$`)
+
+// ValidateCounty validates the ADIF county shape for United States DXCC
+// entities. Other countries use program-specific subdivision formats, which
+// are preserved unchanged.
+func ValidateCounty(county, dxcc, state string) (ref, errorMsg string) {
+	county = strings.TrimSpace(county)
+	if dxcc != "6" && dxcc != "110" && dxcc != "291" {
+		return county, ""
+	}
+
+	matches := validUSCountyRegexp.FindStringSubmatch(county)
+	if len(matches) != 3 {
+		errorMsg = "[" + county + "] is an invalid U.S. county; expected STATE,County"
+		return "*" + county, errorMsg
+	}
+
+	countyState := strings.ToUpper(matches[1])
+	if state != "" && !strings.EqualFold(countyState, state) {
+		errorMsg = fmt.Sprintf("[%s] county state does not match MyState [%s]", county, state)
+		return "*" + county, errorMsg
+	}
+
+	return countyState + "," + strings.TrimSpace(matches[2]), ""
 }
 
 // ValidateSota verifies whether the supplied string is a valid SOTA reference.

--- a/fleprocess/validate_test.go
+++ b/fleprocess/validate_test.go
@@ -4,6 +4,71 @@ import (
 	"testing"
 )
 
+func TestValidateAltitude(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantRef string
+		wantErr bool
+	}{
+		{input: "611", wantRef: "611"},
+		{input: "-12.5", wantRef: "-12.5"},
+		{input: "not-a-number", wantRef: "*not-a-number", wantErr: true},
+		{input: "NaN", wantRef: "*NaN", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		gotRef, gotError := ValidateAltitude(tt.input)
+		if gotRef != tt.wantRef || (gotError != "") != tt.wantErr {
+			t.Fatalf("ValidateAltitude(%q) = (%q, %q), want ref %q, error=%v", tt.input, gotRef, gotError, tt.wantRef, tt.wantErr)
+		}
+	}
+}
+
+func TestValidateDXCC(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantRef string
+		wantErr bool
+	}{
+		{input: "291", wantRef: "291"},
+		{input: "000", wantRef: "0"},
+		{input: "-1", wantRef: "*-1", wantErr: true},
+		{input: "USA", wantRef: "*USA", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		gotRef, gotError := ValidateDXCC(tt.input)
+		if gotRef != tt.wantRef || (gotError != "") != tt.wantErr {
+			t.Fatalf("ValidateDXCC(%q) = (%q, %q), want ref %q, error=%v", tt.input, gotRef, gotError, tt.wantRef, tt.wantErr)
+		}
+	}
+}
+
+func TestValidateCounty(t *testing.T) {
+	tests := []struct {
+		name    string
+		county  string
+		dxcc    string
+		state   string
+		wantRef string
+		wantErr bool
+	}{
+		{name: "US county", county: "ma,Worcester", dxcc: "291", state: "MA", wantRef: "MA,Worcester"},
+		{name: "US county missing state", county: "Worcester", dxcc: "291", state: "MA", wantRef: "*Worcester", wantErr: true},
+		{name: "US county state mismatch", county: "NH,Strafford", dxcc: "291", state: "MA", wantRef: "*NH,Strafford", wantErr: true},
+		{name: "non-US subdivision preserved", county: "AB-01", dxcc: "15", wantRef: "AB-01"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRef, gotError := ValidateCounty(tt.county, tt.dxcc, tt.state)
+			if gotRef != tt.wantRef || (gotError != "") != tt.wantErr {
+				t.Fatalf("ValidateCounty() = (%q, %q), want ref %q, error=%v", gotRef, gotError, tt.wantRef, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateWwff(t *testing.T) {
 	type args struct {
 		inputStr string
@@ -139,12 +204,12 @@ func TestValidatePota(t *testing.T) {
 			args{inputStr: "k-10177"},
 			"K-10177", "",
 		},
-				{
+		{
 			"Good ref (5 digit park) with new US reference",
 			args{inputStr: "us-10177"},
 			"US-10177", "",
 		},
-				{
+		{
 			"Good ref (5 digit park) with sub regional prefix",
 			args{inputStr: "AT-tir-10177"},
 			"AT-TIR-10177", "",

--- a/test/data/fle-adif-location.txt
+++ b/test/data/fle-adif-location.txt
@@ -1,0 +1,14 @@
+mycall AB1WX
+operator AB1WX
+mygrid FN42bl
+myaltitude 611
+mycity Princeton
+mycounty ma,Worcester
+mystate ma
+mycountry United States
+mydxcc 291
+
+date 2026-08-01
+cw
+20m
+2000 K1ABC 9 9


### PR DESCRIPTION
## Summary

- add myaltitude, mycity, mystate, mycountry, and mydxcc header directives
- propagate the station location values to every parsed QSO
- export them as MY_ALTITUDE, MY_CITY, MY_STATE, MY_COUNTRY, and MY_DXCC
- validate finite numeric altitude and non-negative DXCC code syntax
- normalize and validate U.S. mycounty values as STATE,County when the logging-station DXCC is 6, 110, or 291
- document the directives and add unit plus end-to-end tests

## Relationship to #172

This is the input-syntax expansion step and is intentionally separate from #172. PR #172 corrects and enriches output for location and program-reference inputs FLEcli already supports. Both changes are complementary; #172 should ideally merge first so existing decimal mylat/mylon values are also encoded correctly.

## ADIF version

MY_ALTITUDE requires a newer ADIF specification than the currently declared 3.1.0, so this PR updates ADIF_VER to 3.1.7 independently.

## Validation

- go test ./...
- go test -race -count=1 ./...
- go vet ./...